### PR TITLE
fix(result): fix diagram clipping and h1 アーキテクチャ format (LA-012)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/src/modules/result/ResultView.tsx
+++ b/src/modules/result/ResultView.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import Link from "next/link";
 import type { DiagnosisResult, Diagnosis } from "@/types";
 import dynamic from "next/dynamic";
 
@@ -99,7 +100,7 @@ export default function ResultView({ result, diagnosis, isOwner, isLoggedIn }: P
             <p style={{ color: "var(--color-text-muted)", fontFamily: "var(--font-body)", fontSize: "0.875rem" }}>
               GitHubログインで自分の診断を保存できます
             </p>
-            <a
+            <Link
               href="/"
               style={{
                 color: "var(--color-accent)",
@@ -109,7 +110,7 @@ export default function ResultView({ result, diagnosis, isOwner, isLoggedIn }: P
               }}
             >
               ログイン →
-            </a>
+            </Link>
           </div>
         )}
 
@@ -143,7 +144,7 @@ export default function ResultView({ result, diagnosis, isOwner, isLoggedIn }: P
               marginBottom: "16px",
             }}
           >
-            {result.architecture_name}
+            {result.architecture_name}アーキテクチャ
           </h1>
           <p
             style={{
@@ -198,8 +199,6 @@ export default function ResultView({ result, diagnosis, isOwner, isLoggedIn }: P
               backgroundColor: "var(--color-surface)",
               border: "1px solid var(--color-border)",
               borderRadius: "8px",
-              height: "min(88vh, 1000px)",
-              overflow: "hidden",
             }}
           >
             <ArchitectureDiagram

--- a/src/modules/visualization/ArchitectureDiagram.tsx
+++ b/src/modules/visualization/ArchitectureDiagram.tsx
@@ -196,8 +196,6 @@ export default function ArchitectureDiagram({ diagramData, activeFlowId }: Props
   return (
     <div
       style={{
-        height: "100%",
-        overflowY: "hidden",
         padding: "20px",
         display: "grid",
         gap: "18px",

--- a/tools/orchestrator/orchestrate/skills.config.toml
+++ b/tools/orchestrator/orchestrate/skills.config.toml
@@ -33,6 +33,7 @@ fail_on_unmapped_scope = true
 
 ["orchestrate".profiles."remote-pr-default".worktree_gate.scope_gate_cmds]
 repo = "npm run lint"
+ops = "bun run typecheck"
 
 # fast-iteration: skip quality gates for rapid prototyping.
 ["orchestrate".profiles."fast-iteration"]
@@ -77,3 +78,4 @@ fail_on_unmapped_scope = true
 ["orchestrate".profiles."claude-execute".worktree_gate.scope_gate_cmds]
 # Match the default repo gate for command-exec mode.
 repo = "npm run lint"
+ops = "bun run typecheck"

--- a/tools/orchestrator/orchestrate/skills.config.toml
+++ b/tools/orchestrator/orchestrate/skills.config.toml
@@ -12,7 +12,7 @@ writing_language = "ja"
 
 ["orchestrate".defaults.child_exec]
 cmd = "claude"
-args = "--dangerously-skip-permissions"
+args = "--dangerously-skip-permissions --output-format stream-json"
 
 ["orchestrate".defaults.runtime_policy]
 max_runtime_seconds = 3600

--- a/tools/orchestrator/orchestrate/skills.config.toml
+++ b/tools/orchestrator/orchestrate/skills.config.toml
@@ -12,7 +12,7 @@ writing_language = "ja"
 
 ["orchestrate".defaults.child_exec]
 cmd = "claude"
-args = "--dangerously-skip-permissions --output-format stream-json"
+args = "--dangerously-skip-permissions --output-format stream-json --verbose"
 
 ["orchestrate".defaults.runtime_policy]
 max_runtime_seconds = 3600


### PR DESCRIPTION
## Summary

- アーキテクチャ図が下部で切れる問題を修正: ResultView の diagram コンテナから `height: min(88vh, 1000px)` と `overflow: hidden` を削除、ArchitectureDiagram root div から `height: 100%` と `overflowY: hidden` を削除
- h1 を `{architecture_name}アーキテクチャ` 形式に変更
- 既存の lint エラー: `<a href="/">` → `<Link href="/">` を修正
- `.eslintrc.json` を追加して `npm run lint` が非対話式で実行できるよう対応

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)